### PR TITLE
Correct the speak parameter to generate correct OpenAPI document

### DIFF
--- a/ConferenceAPI/Program.cs
+++ b/ConferenceAPI/Program.cs
@@ -105,10 +105,10 @@ app.MapGet("/speakers", () =>
 });
 //.WithName("GetSpeakers")
 //.WithOpenApi();
-app.MapGet("/speaker/{id}", (string speakerID) =>
+app.MapGet("/speaker/{id}", (string id) =>
 {
     var speakers = ReadSpeakersFromFile("transformed_speakers.json");
-    return speakers.Find(sp => sp.speakerID == speakerID);
+    return speakers.Find(sp => sp.speakerID == id);
 });
 
 app.MapGet("/topics", () =>


### PR DESCRIPTION
When importing the swagger json document, Azure APIM rejects the document due to the mismatch. You can validate the documents pre and post at https://editor.swagger.io/